### PR TITLE
Fix broken banner link

### DIFF
--- a/theme/modules/change-logo.css
+++ b/theme/modules/change-logo.css
@@ -5,7 +5,7 @@
 */
 
 :root {
-    --logo-url: url('https://raw.githubusercontent.com/JamsRepos/Jamfin@latest/main/assets/banner.png');
+    --logo-url: url('https://cdn.jsdelivr.net/gh/JamsRepos/Jamfin@latest/assets/banner.png');
 }
 
 .pageTitleWithDefaultLogo,


### PR DESCRIPTION
current banner image link 404s and this change corrects that

## Summary by Sourcery

Bug Fixes:
- Update the CSS --logo-url variable to point to the jsDelivr CDN instead of raw.githubusercontent, resolving the 404 error